### PR TITLE
Support caBundle patching into APIService

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@
 
 # Vendored Dependencies
 vendor/
+
+# binaries
+wcg

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.9 AS builder
+FROM golang:1.11 AS builder
 WORKDIR /go/src/github.com/joelspeed/webhook-certificate-generator
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -o /bin/wcg github.com/joelspeed/webhook-certificate-generator/cmd/webhook-certificate-generator

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,212 +2,637 @@
 
 
 [[projects]]
+  digest = "1:a639b30711f62030ade1432a6bcf135c23c38607d1478d3ce53829ea2a664197"
   name = "cloud.google.com/go"
   packages = ["compute/metadata"]
-  revision = "20d4028b8a750c2aca76bf9fefa8ed2d0109b573"
-  version = "v0.19.0"
+  pruneopts = ""
+  revision = "0ebda48a7f143b1cce9eb37a8c1106ac762a3430"
+  version = "v0.34.0"
 
 [[projects]]
+  digest = "1:e222cbd536d9e0850e7297290c431aea75ba087c70d6f98525e95b9f2d02a627"
   name = "github.com/Azure/go-autorest"
-  packages = ["autorest","autorest/adal","autorest/azure","autorest/date"]
-  revision = "fc3b03a2d2d1f43fad3007038bd16f044f870722"
-  version = "v9.10.0"
+  packages = [
+    "autorest",
+    "autorest/adal",
+    "autorest/azure",
+    "autorest/date",
+    "version",
+  ]
+  pruneopts = ""
+  revision = "bca49d5b51a50dc5bb17bbf6204c711c6dbded06"
 
 [[projects]]
+  digest = "1:6098222470fe0172157ce9bbef5d2200df4edde17ee649c5d6e48330e4afa4c6"
   name = "github.com/dgrijalva/jwt-go"
   packages = ["."]
-  revision = "dbeaa9332f19a944acb5736b4456cfcc02140e29"
-  version = "v3.1.0"
+  pruneopts = ""
+  revision = "06ea1031745cb8b3dab3f6a236daf2b0aa468b7e"
+  version = "v3.2.0"
 
 [[projects]]
+  digest = "1:4600ac901b8fa13c722175d3eeedd961c62a8453de16e13952f447aaefc8b544"
+  name = "github.com/docker/distribution"
+  packages = [
+    "digestset",
+    "reference",
+  ]
+  pruneopts = ""
+  revision = "40b7b5830a2337bb07627617740c0e39eb92800c"
+  version = "v2.7.0"
+
+[[projects]]
+  digest = "1:b13707423743d41665fd23f0c36b2f37bb49c30e94adb813319c44188a51ba22"
   name = "github.com/ghodss/yaml"
   packages = ["."]
+  pruneopts = ""
   revision = "0ca9ea5df5451ffdf184b4428c902747c2c11cd7"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:527e1e468c5586ef2645d143e9f5fbd50b4fe5abc8b1e25d9f1c416d22d24895"
   name = "github.com/gogo/protobuf"
-  packages = ["proto","sortkeys"]
-  revision = "1adfc126b41513cc696b209667c8656ea7aac67c"
-  version = "v1.0.0"
+  packages = [
+    "proto",
+    "sortkeys",
+  ]
+  pruneopts = ""
+  revision = "4cbf7e384e768b4e01799441fdf2a706a5635ae7"
+  version = "v1.2.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:107b233e45174dbab5b1324201d092ea9448e58243ab9f039e4c0f332e121e3a"
   name = "github.com/golang/glog"
   packages = ["."]
+  pruneopts = ""
   revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
 
 [[projects]]
+  digest = "1:3dd078fda7500c341bc26cfbc6c6a34614f295a2457149fc1045cab767cbcf18"
   name = "github.com/golang/protobuf"
-  packages = ["proto","ptypes","ptypes/any","ptypes/duration","ptypes/timestamp"]
-  revision = "925541529c1fa6821df4e44ce2723319eb2be768"
-  version = "v1.0.0"
+  packages = [
+    "proto",
+    "ptypes",
+    "ptypes/any",
+    "ptypes/duration",
+    "ptypes/timestamp",
+  ]
+  pruneopts = ""
+  revision = "aa810b61a9c79d51363740d207bb46cf8e620ed5"
+  version = "v1.2.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:1e5b1e14524ed08301977b7b8e10c719ed853cbf3f24ecb66fae783a46f207a6"
   name = "github.com/google/btree"
   packages = ["."]
-  revision = "e89373fe6b4a7413d7acd6da1725b83ef713e6e4"
+  pruneopts = ""
+  revision = "4030bb1f1f0c35b30ca7009e9ebd06849dd45306"
 
 [[projects]]
   branch = "master"
+  digest = "1:754f77e9c839b24778a4b64422236d38515301d2baeb63113aa3edc42e6af692"
   name = "github.com/google/gofuzz"
   packages = ["."]
+  pruneopts = ""
   revision = "24818f796faf91cd76ec7bddd72458fbced7a6c1"
 
 [[projects]]
+  digest = "1:16b2837c8b3cf045fa2cdc82af0cf78b19582701394484ae76b2c3bc3c99ad73"
   name = "github.com/googleapis/gnostic"
-  packages = ["OpenAPIv2","compiler","extensions"]
-  revision = "ee43cbb60db7bd22502942cccbc39059117352ab"
-  version = "v0.1.0"
+  packages = [
+    "OpenAPIv2",
+    "compiler",
+    "extensions",
+  ]
+  pruneopts = ""
+  revision = "7c663266750e7d82587642f65e60bc4083f1f84e"
+  version = "v0.2.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:01bc29af297490f832dbfa9d9eee3d4c5d216301edbe2e1db9226e6049e28606"
   name = "github.com/gophercloud/gophercloud"
-  packages = [".","openstack","openstack/identity/v2/tenants","openstack/identity/v2/tokens","openstack/identity/v3/tokens","openstack/utils","pagination"]
-  revision = "32083cdce4c64eff52ec57f82b2d3b522d1ba48a"
+  packages = [
+    ".",
+    "openstack",
+    "openstack/identity/v2/tenants",
+    "openstack/identity/v2/tokens",
+    "openstack/identity/v3/tokens",
+    "openstack/utils",
+    "pagination",
+  ]
+  pruneopts = ""
+  revision = "a1de06b8040b6da28b21c6f32b446b836d475b04"
 
 [[projects]]
   branch = "master"
+  digest = "1:5e345eb75d8bfb2b91cfbfe02a82a79c0b2ea55cf06c5a4d180a9321f36973b4"
   name = "github.com/gregjones/httpcache"
-  packages = [".","diskcache"]
-  revision = "2bcd89a1743fd4b373f7370ce8ddc14dfbd18229"
+  packages = [
+    ".",
+    "diskcache",
+  ]
+  pruneopts = ""
+  revision = "c63ab54fda8f77302f8d414e19933f2b6026a089"
 
 [[projects]]
-  branch = "master"
-  name = "github.com/howeyc/gopass"
-  packages = ["."]
-  revision = "bf9dde6d0d2c004a008c27aaee91170c786f6db8"
-
-[[projects]]
+  digest = "1:7ab38c15bd21e056e3115c8b526d201eaf74e0308da9370997c6b3c187115d36"
   name = "github.com/imdario/mergo"
   packages = ["."]
-  revision = "163f41321a19dd09362d4c63cc2489db2015f1f4"
-  version = "0.3.2"
+  pruneopts = ""
+  revision = "9f23e2d6bd2a77f959b2bf6acdbefd708a83a4a4"
+  version = "v0.3.6"
 
 [[projects]]
+  digest = "1:870d441fe217b8e689d7949fef6e43efbc787e50f200cb1e70dbca9204a1d6be"
   name = "github.com/inconshreveable/mousetrap"
   packages = ["."]
+  pruneopts = ""
   revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
   version = "v1.0"
 
 [[projects]]
+  digest = "1:b79fc583e4dc7055ed86742e22164ac41bf8c0940722dbcb600f1a3ace1a8cb5"
   name = "github.com/json-iterator/go"
   packages = ["."]
-  revision = "3353055b2a1a5ae1b6a8dfde887a524e7088f3a2"
-  version = "1.1.2"
+  pruneopts = ""
+  revision = "1624edc4454b8682399def8740d46db5e4362ba4"
+  version = "v1.1.5"
 
 [[projects]]
-  name = "github.com/juju/ratelimit"
+  digest = "1:0c0ff2a89c1bb0d01887e1dac043ad7efbf3ec77482ef058ac423d13497e16fd"
+  name = "github.com/modern-go/concurrent"
   packages = ["."]
-  revision = "59fac5042749a5afb9af70e813da1dd5474f0167"
+  pruneopts = ""
+  revision = "bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94"
+  version = "1.0.3"
+
+[[projects]]
+  digest = "1:e32bdbdb7c377a07a9a46378290059822efdce5c8d96fe71940d87cb4f918855"
+  name = "github.com/modern-go/reflect2"
+  packages = ["."]
+  pruneopts = ""
+  revision = "4b7aa43c6742a2c18fdef89dd197aaae7dac7ccd"
   version = "1.0.1"
 
 [[projects]]
-  name = "github.com/modern-go/concurrent"
+  digest = "1:5d9b668b0b4581a978f07e7d2e3314af18eb27b3fb5d19b70185b7c575723d11"
+  name = "github.com/opencontainers/go-digest"
   packages = ["."]
-  revision = "938152ca6a933f501bb238954eebd3cbcbf489ff"
-  version = "1.0.2"
-
-[[projects]]
-  name = "github.com/modern-go/reflect2"
-  packages = ["."]
-  revision = "1df9eeb2bb81f327b96228865c5687bc2194af3f"
-  version = "1.0.0"
+  pruneopts = ""
+  revision = "279bed98673dd5bef374d3b6e4b09e2af76183bf"
+  version = "v1.0.0-rc1"
 
 [[projects]]
   branch = "master"
+  digest = "1:c24598ffeadd2762552269271b3b1510df2d83ee6696c1e543a0ff653af494bc"
   name = "github.com/petar/GoLLRB"
   packages = ["llrb"]
+  pruneopts = ""
   revision = "53be0d36a84c2a886ca057d34b6aa4468df9ccb4"
 
 [[projects]]
+  digest = "1:b46305723171710475f2dd37547edd57b67b9de9f2a6267cafdd98331fd6897f"
   name = "github.com/peterbourgon/diskv"
   packages = ["."]
+  pruneopts = ""
   revision = "5f041e8faa004a95c88a202771f4cc3e991971e6"
   version = "v2.0.1"
 
 [[projects]]
+  digest = "1:a1403cc8a94b8d7956ee5e9694badef0e7b051af289caad1cf668331e3ffa4f6"
   name = "github.com/spf13/cobra"
   packages = ["."]
-  revision = "7b2c5ac9fc04fc5efafb60700713d4fa609b777b"
-  version = "v0.0.1"
+  pruneopts = ""
+  revision = "ef82de70bb3f60c65fb8eebacbb2d122ef517385"
+  version = "v0.0.3"
 
 [[projects]]
+  digest = "1:cbaf13cdbfef0e4734ed8a7504f57fe893d471d62a35b982bf6fb3f036449a66"
   name = "github.com/spf13/pflag"
   packages = ["."]
-  revision = "e57e3eeb33f795204c1ca35f56c44f83227c6e66"
-  version = "v1.0.0"
+  pruneopts = ""
+  revision = "298182f68c66c05229eb03ac171abe6e309ee79a"
+  version = "v1.0.3"
 
 [[projects]]
   branch = "master"
+  digest = "1:59b49c47c11a48f1054529207f65907c014ecf5f9a7c0d9c0f1616dec7b062ed"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
-  revision = "91a49db82a88618983a78a06c1cbd4e00ab749ab"
+  pruneopts = ""
+  revision = "ff983b9c42bc9fbf91556e191cc8efb585c16908"
 
 [[projects]]
   branch = "master"
+  digest = "1:4ab2fc83e3222b69759dfd717e01d0cf38b133aabfacc29a86057021a2f1abd9"
   name = "golang.org/x/net"
-  packages = ["context","context/ctxhttp","http2","http2/hpack","idna","lex/httplex"]
-  revision = "22ae77b79946ea320088417e4d50825671d82d57"
+  packages = [
+    "context",
+    "context/ctxhttp",
+    "http/httpguts",
+    "http2",
+    "http2/hpack",
+    "idna",
+  ]
+  pruneopts = ""
+  revision = "927f97764cc334a6575f4b7a1584a147864d5723"
 
 [[projects]]
   branch = "master"
+  digest = "1:ea010cdb976f9de0c763728a76278f9109fca3299abd0dc3e8f2ccb9ff347268"
   name = "golang.org/x/oauth2"
-  packages = [".","google","internal","jws","jwt"]
-  revision = "2f32c3ac0fa4fb807a0fcefb0b6f2468a0d99bd0"
+  packages = [
+    ".",
+    "google",
+    "internal",
+    "jws",
+    "jwt",
+  ]
+  pruneopts = ""
+  revision = "d668ce993890a79bda886613ee587a69dd5da7a6"
 
 [[projects]]
   branch = "master"
+  digest = "1:528fd80cf9b601eec370e035bfa4b32dc98bb4dbf64de45686387249dd82a7cd"
   name = "golang.org/x/sys"
-  packages = ["unix","windows"]
-  revision = "dd2ff4accc098aceecb86b36eaa7829b2a17b1c9"
+  packages = [
+    "unix",
+    "windows",
+  ]
+  pruneopts = ""
+  revision = "82a175fd1598e8a172e58ebdf5ed262bb29129e5"
 
 [[projects]]
+  digest = "1:5acd3512b047305d49e8763eef7ba423901e85d5dd2fd1e71778a0ea8de10bd4"
   name = "golang.org/x/text"
-  packages = ["collate","collate/build","internal/colltab","internal/gen","internal/tag","internal/triegen","internal/ucd","language","secure/bidirule","transform","unicode/bidi","unicode/cldr","unicode/norm","unicode/rangetable"]
+  packages = [
+    "collate",
+    "collate/build",
+    "internal/colltab",
+    "internal/gen",
+    "internal/tag",
+    "internal/triegen",
+    "internal/ucd",
+    "language",
+    "secure/bidirule",
+    "transform",
+    "unicode/bidi",
+    "unicode/cldr",
+    "unicode/norm",
+    "unicode/rangetable",
+  ]
+  pruneopts = ""
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
 [[projects]]
-  name = "google.golang.org/appengine"
-  packages = [".","internal","internal/app_identity","internal/base","internal/datastore","internal/log","internal/modules","internal/remote_api","internal/urlfetch","urlfetch"]
-  revision = "150dc57a1b433e64154302bdc40b6bb8aefa313a"
-  version = "v1.0.0"
+  branch = "master"
+  digest = "1:14cb1d4240bcbbf1386ae763957e04e2765ec4e4ce7bb2769d05fa6faccd774e"
+  name = "golang.org/x/time"
+  packages = ["rate"]
+  pruneopts = ""
+  revision = "85acf8d2951cb2a3bde7632f9ff273ef0379bcbd"
 
 [[projects]]
+  digest = "1:bc09e719c4e2a15d17163f5272d9a3131c45d77542b7fdc53ff518815bc19ab3"
+  name = "google.golang.org/appengine"
+  packages = [
+    ".",
+    "internal",
+    "internal/app_identity",
+    "internal/base",
+    "internal/datastore",
+    "internal/log",
+    "internal/modules",
+    "internal/remote_api",
+    "internal/urlfetch",
+    "urlfetch",
+  ]
+  pruneopts = ""
+  revision = "e9657d882bb81064595ca3b56cbe2546bbabf7b1"
+  version = "v1.4.0"
+
+[[projects]]
+  digest = "1:75fb3fcfc73a8c723efde7777b40e8e8ff9babf30d8c56160d01beffea8a95a6"
   name = "gopkg.in/inf.v0"
   packages = ["."]
-  revision = "3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4"
-  version = "v0.9.0"
+  pruneopts = ""
+  revision = "d2d2541c53f18d2a059457998ce2876cc8e67cbf"
+  version = "v0.9.1"
 
 [[projects]]
+  digest = "1:cedccf16b71e86db87a24f8d4c70b0a855872eb967cb906a66b95de56aefbd0d"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
-  revision = "7f97868eec74b32b0982dd158a51a446d1da7eb5"
-  version = "v2.1.1"
+  pruneopts = ""
+  revision = "51d6538a90f86fe93ac480b35f37b2be17fef232"
+  version = "v2.2.2"
 
 [[projects]]
-  branch = "master"
+  branch = "release-1.11"
+  digest = "1:0a64a62b398949a3a2d9bfe58abea92aa826f80a8f6c2e3f8b33945425ebcd42"
   name = "k8s.io/api"
-  packages = ["admissionregistration/v1alpha1","admissionregistration/v1beta1","apps/v1","apps/v1beta1","apps/v1beta2","authentication/v1","authentication/v1beta1","authorization/v1","authorization/v1beta1","autoscaling/v1","autoscaling/v2beta1","batch/v1","batch/v1beta1","batch/v2alpha1","certificates/v1beta1","core/v1","events/v1beta1","extensions/v1beta1","networking/v1","policy/v1beta1","rbac/v1","rbac/v1alpha1","rbac/v1beta1","scheduling/v1alpha1","settings/v1alpha1","storage/v1","storage/v1alpha1","storage/v1beta1"]
-  revision = "7ebfdc5e7dfac82cc5c53e1259ad579915950e20"
+  packages = [
+    "admissionregistration/v1alpha1",
+    "admissionregistration/v1beta1",
+    "apps/v1",
+    "apps/v1beta1",
+    "apps/v1beta2",
+    "authentication/v1",
+    "authentication/v1beta1",
+    "authorization/v1",
+    "authorization/v1beta1",
+    "autoscaling/v1",
+    "autoscaling/v2beta1",
+    "batch/v1",
+    "batch/v1beta1",
+    "batch/v2alpha1",
+    "certificates/v1beta1",
+    "core/v1",
+    "events/v1beta1",
+    "extensions/v1beta1",
+    "networking/v1",
+    "policy/v1beta1",
+    "rbac/v1",
+    "rbac/v1alpha1",
+    "rbac/v1beta1",
+    "scheduling/v1alpha1",
+    "scheduling/v1beta1",
+    "settings/v1alpha1",
+    "storage/v1",
+    "storage/v1alpha1",
+    "storage/v1beta1",
+  ]
+  pruneopts = ""
+  revision = "2dd39edadc55ab8a4ab2b27b84a9ed1b467ef47e"
 
 [[projects]]
-  branch = "master"
+  branch = "release-1.11"
+  digest = "1:9affbbf1de50794b4724fe97256f4a290e1c9367807acc2b371a242e88d08074"
+  name = "k8s.io/apiextensions-apiserver"
+  packages = ["pkg/features"]
+  pruneopts = ""
+  revision = "e419c5771cdcec16d68b632a451dab1d383168a8"
+
+[[projects]]
+  branch = "release-1.11"
+  digest = "1:2b9b504b5776d0c9dd2578d35e1e6eb8868fe8926461d0b7533a5a82a618551a"
   name = "k8s.io/apimachinery"
-  packages = ["pkg/api/errors","pkg/api/meta","pkg/api/resource","pkg/apis/meta/v1","pkg/apis/meta/v1/unstructured","pkg/apis/meta/v1beta1","pkg/conversion","pkg/conversion/queryparams","pkg/fields","pkg/labels","pkg/runtime","pkg/runtime/schema","pkg/runtime/serializer","pkg/runtime/serializer/json","pkg/runtime/serializer/protobuf","pkg/runtime/serializer/recognizer","pkg/runtime/serializer/streaming","pkg/runtime/serializer/versioning","pkg/selection","pkg/types","pkg/util/clock","pkg/util/errors","pkg/util/framer","pkg/util/intstr","pkg/util/json","pkg/util/net","pkg/util/runtime","pkg/util/sets","pkg/util/validation","pkg/util/validation/field","pkg/util/wait","pkg/util/yaml","pkg/version","pkg/watch","third_party/forked/golang/reflect"]
-  revision = "e9ff529c66f83aeac6dff90f11ea0c5b7c4d626a"
+  packages = [
+    "pkg/api/errors",
+    "pkg/api/meta",
+    "pkg/api/resource",
+    "pkg/apis/meta/internalversion",
+    "pkg/apis/meta/v1",
+    "pkg/apis/meta/v1/unstructured",
+    "pkg/apis/meta/v1beta1",
+    "pkg/conversion",
+    "pkg/conversion/queryparams",
+    "pkg/fields",
+    "pkg/labels",
+    "pkg/runtime",
+    "pkg/runtime/schema",
+    "pkg/runtime/serializer",
+    "pkg/runtime/serializer/json",
+    "pkg/runtime/serializer/protobuf",
+    "pkg/runtime/serializer/recognizer",
+    "pkg/runtime/serializer/streaming",
+    "pkg/runtime/serializer/versioning",
+    "pkg/selection",
+    "pkg/types",
+    "pkg/util/clock",
+    "pkg/util/errors",
+    "pkg/util/framer",
+    "pkg/util/intstr",
+    "pkg/util/json",
+    "pkg/util/net",
+    "pkg/util/runtime",
+    "pkg/util/sets",
+    "pkg/util/validation",
+    "pkg/util/validation/field",
+    "pkg/util/wait",
+    "pkg/util/yaml",
+    "pkg/version",
+    "pkg/watch",
+    "third_party/forked/golang/reflect",
+  ]
+  pruneopts = ""
+  revision = "3d8ee2261517413977a62256b7d79644d7ffdc43"
 
 [[projects]]
+  branch = "release-1.11"
+  digest = "1:68673bd491187e09c88e846b3d52eed063ca191a48cc6d28f2e312ee00bfa485"
+  name = "k8s.io/apiserver"
+  packages = [
+    "pkg/features",
+    "pkg/util/feature",
+  ]
+  pruneopts = ""
+  revision = "6ac0a117b7dfe4162258c1285c5b3b383070efd5"
+
+[[projects]]
+  branch = "release-8.0"
+  digest = "1:5e0a4eaf460ad67c1ac99d13753b604a81bec77ac8eacfd0fdc03f04128f2989"
   name = "k8s.io/client-go"
-  packages = ["discovery","kubernetes","kubernetes/scheme","kubernetes/typed/admissionregistration/v1alpha1","kubernetes/typed/admissionregistration/v1beta1","kubernetes/typed/apps/v1","kubernetes/typed/apps/v1beta1","kubernetes/typed/apps/v1beta2","kubernetes/typed/authentication/v1","kubernetes/typed/authentication/v1beta1","kubernetes/typed/authorization/v1","kubernetes/typed/authorization/v1beta1","kubernetes/typed/autoscaling/v1","kubernetes/typed/autoscaling/v2beta1","kubernetes/typed/batch/v1","kubernetes/typed/batch/v1beta1","kubernetes/typed/batch/v2alpha1","kubernetes/typed/certificates/v1beta1","kubernetes/typed/core/v1","kubernetes/typed/events/v1beta1","kubernetes/typed/extensions/v1beta1","kubernetes/typed/networking/v1","kubernetes/typed/policy/v1beta1","kubernetes/typed/rbac/v1","kubernetes/typed/rbac/v1alpha1","kubernetes/typed/rbac/v1beta1","kubernetes/typed/scheduling/v1alpha1","kubernetes/typed/settings/v1alpha1","kubernetes/typed/storage/v1","kubernetes/typed/storage/v1alpha1","kubernetes/typed/storage/v1beta1","pkg/version","plugin/pkg/client/auth","plugin/pkg/client/auth/azure","plugin/pkg/client/auth/gcp","plugin/pkg/client/auth/oidc","plugin/pkg/client/auth/openstack","rest","rest/watch","third_party/forked/golang/template","tools/auth","tools/clientcmd","tools/clientcmd/api","tools/clientcmd/api/latest","tools/clientcmd/api/v1","tools/metrics","tools/reference","transport","util/cert","util/flowcontrol","util/homedir","util/integer","util/jsonpath"]
-  revision = "78700dec6369ba22221b72770783300f143df150"
-  version = "v6.0.0"
+  packages = [
+    "discovery",
+    "kubernetes",
+    "kubernetes/scheme",
+    "kubernetes/typed/admissionregistration/v1alpha1",
+    "kubernetes/typed/admissionregistration/v1beta1",
+    "kubernetes/typed/apps/v1",
+    "kubernetes/typed/apps/v1beta1",
+    "kubernetes/typed/apps/v1beta2",
+    "kubernetes/typed/authentication/v1",
+    "kubernetes/typed/authentication/v1beta1",
+    "kubernetes/typed/authorization/v1",
+    "kubernetes/typed/authorization/v1beta1",
+    "kubernetes/typed/autoscaling/v1",
+    "kubernetes/typed/autoscaling/v2beta1",
+    "kubernetes/typed/batch/v1",
+    "kubernetes/typed/batch/v1beta1",
+    "kubernetes/typed/batch/v2alpha1",
+    "kubernetes/typed/certificates/v1beta1",
+    "kubernetes/typed/core/v1",
+    "kubernetes/typed/events/v1beta1",
+    "kubernetes/typed/extensions/v1beta1",
+    "kubernetes/typed/networking/v1",
+    "kubernetes/typed/policy/v1beta1",
+    "kubernetes/typed/rbac/v1",
+    "kubernetes/typed/rbac/v1alpha1",
+    "kubernetes/typed/rbac/v1beta1",
+    "kubernetes/typed/scheduling/v1alpha1",
+    "kubernetes/typed/scheduling/v1beta1",
+    "kubernetes/typed/settings/v1alpha1",
+    "kubernetes/typed/storage/v1",
+    "kubernetes/typed/storage/v1alpha1",
+    "kubernetes/typed/storage/v1beta1",
+    "pkg/apis/clientauthentication",
+    "pkg/apis/clientauthentication/v1alpha1",
+    "pkg/apis/clientauthentication/v1beta1",
+    "pkg/version",
+    "plugin/pkg/client/auth",
+    "plugin/pkg/client/auth/azure",
+    "plugin/pkg/client/auth/exec",
+    "plugin/pkg/client/auth/gcp",
+    "plugin/pkg/client/auth/oidc",
+    "plugin/pkg/client/auth/openstack",
+    "rest",
+    "rest/watch",
+    "third_party/forked/golang/template",
+    "tools/auth",
+    "tools/clientcmd",
+    "tools/clientcmd/api",
+    "tools/clientcmd/api/latest",
+    "tools/clientcmd/api/v1",
+    "tools/metrics",
+    "tools/reference",
+    "transport",
+    "util/cert",
+    "util/connrotation",
+    "util/flowcontrol",
+    "util/homedir",
+    "util/integer",
+    "util/jsonpath",
+  ]
+  pruneopts = ""
+  revision = "573fc71f7a51eb0720524b3973d465dcde5566e6"
+
+[[projects]]
+  branch = "release-1.11"
+  digest = "1:d0cc1a36e10cc298e8f6df8fd724eb334a3cb85649794724cffe7687ceda8d42"
+  name = "k8s.io/kube-aggregator"
+  packages = [
+    "pkg/apis/apiregistration",
+    "pkg/apis/apiregistration/v1",
+    "pkg/apis/apiregistration/v1beta1",
+    "pkg/client/clientset_generated/clientset",
+    "pkg/client/clientset_generated/clientset/scheme",
+    "pkg/client/clientset_generated/clientset/typed/apiregistration/v1",
+    "pkg/client/clientset_generated/clientset/typed/apiregistration/v1beta1",
+  ]
+  pruneopts = ""
+  revision = "122bac39d429efc37f37b6eea90d6402fdb70f33"
+
+[[projects]]
+  branch = "release-1.11"
+  digest = "1:0ca0cdbc967d31837863ca1c01a11e402ba55c180b11723dc1d0bfeeeea6c471"
+  name = "k8s.io/kubernetes"
+  packages = [
+    "pkg/api/legacyscheme",
+    "pkg/api/ref",
+    "pkg/apis/admissionregistration",
+    "pkg/apis/admissionregistration/install",
+    "pkg/apis/admissionregistration/v1alpha1",
+    "pkg/apis/admissionregistration/v1beta1",
+    "pkg/apis/apps",
+    "pkg/apis/apps/install",
+    "pkg/apis/apps/v1",
+    "pkg/apis/apps/v1beta1",
+    "pkg/apis/apps/v1beta2",
+    "pkg/apis/authentication",
+    "pkg/apis/authentication/install",
+    "pkg/apis/authentication/v1",
+    "pkg/apis/authentication/v1beta1",
+    "pkg/apis/authorization",
+    "pkg/apis/authorization/install",
+    "pkg/apis/authorization/v1",
+    "pkg/apis/authorization/v1beta1",
+    "pkg/apis/autoscaling",
+    "pkg/apis/autoscaling/install",
+    "pkg/apis/autoscaling/v1",
+    "pkg/apis/autoscaling/v2beta1",
+    "pkg/apis/batch",
+    "pkg/apis/batch/install",
+    "pkg/apis/batch/v1",
+    "pkg/apis/batch/v1beta1",
+    "pkg/apis/batch/v2alpha1",
+    "pkg/apis/certificates",
+    "pkg/apis/certificates/install",
+    "pkg/apis/certificates/v1beta1",
+    "pkg/apis/componentconfig",
+    "pkg/apis/componentconfig/install",
+    "pkg/apis/componentconfig/v1alpha1",
+    "pkg/apis/core",
+    "pkg/apis/core/install",
+    "pkg/apis/core/v1",
+    "pkg/apis/events",
+    "pkg/apis/events/install",
+    "pkg/apis/events/v1beta1",
+    "pkg/apis/extensions",
+    "pkg/apis/extensions/install",
+    "pkg/apis/extensions/v1beta1",
+    "pkg/apis/networking",
+    "pkg/apis/networking/install",
+    "pkg/apis/networking/v1",
+    "pkg/apis/policy",
+    "pkg/apis/policy/install",
+    "pkg/apis/policy/v1beta1",
+    "pkg/apis/rbac",
+    "pkg/apis/rbac/install",
+    "pkg/apis/rbac/v1",
+    "pkg/apis/rbac/v1alpha1",
+    "pkg/apis/rbac/v1beta1",
+    "pkg/apis/scheduling",
+    "pkg/apis/scheduling/install",
+    "pkg/apis/scheduling/v1alpha1",
+    "pkg/apis/scheduling/v1beta1",
+    "pkg/apis/settings",
+    "pkg/apis/settings/install",
+    "pkg/apis/settings/v1alpha1",
+    "pkg/apis/storage",
+    "pkg/apis/storage/install",
+    "pkg/apis/storage/v1",
+    "pkg/apis/storage/v1alpha1",
+    "pkg/apis/storage/v1beta1",
+    "pkg/client/clientset_generated/internalclientset",
+    "pkg/client/clientset_generated/internalclientset/scheme",
+    "pkg/client/clientset_generated/internalclientset/typed/admissionregistration/internalversion",
+    "pkg/client/clientset_generated/internalclientset/typed/apps/internalversion",
+    "pkg/client/clientset_generated/internalclientset/typed/authentication/internalversion",
+    "pkg/client/clientset_generated/internalclientset/typed/authorization/internalversion",
+    "pkg/client/clientset_generated/internalclientset/typed/autoscaling/internalversion",
+    "pkg/client/clientset_generated/internalclientset/typed/batch/internalversion",
+    "pkg/client/clientset_generated/internalclientset/typed/certificates/internalversion",
+    "pkg/client/clientset_generated/internalclientset/typed/core/internalversion",
+    "pkg/client/clientset_generated/internalclientset/typed/events/internalversion",
+    "pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion",
+    "pkg/client/clientset_generated/internalclientset/typed/networking/internalversion",
+    "pkg/client/clientset_generated/internalclientset/typed/policy/internalversion",
+    "pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion",
+    "pkg/client/clientset_generated/internalclientset/typed/scheduling/internalversion",
+    "pkg/client/clientset_generated/internalclientset/typed/settings/internalversion",
+    "pkg/client/clientset_generated/internalclientset/typed/storage/internalversion",
+    "pkg/features",
+    "pkg/kubelet/apis",
+    "pkg/master/ports",
+    "pkg/util/parsers",
+    "pkg/util/pointer",
+  ]
+  pruneopts = ""
+  revision = "c1754bd68c86c0b26cc7947e35d6838b5aeaf02b"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "a5afa0cad081b80acb93319192f1fdc78ad79154372d9415cc8b8ef7dcfe1ad4"
+  input-imports = [
+    "github.com/golang/glog",
+    "github.com/spf13/cobra",
+    "k8s.io/api/admissionregistration/v1beta1",
+    "k8s.io/api/certificates/v1beta1",
+    "k8s.io/api/core/v1",
+    "k8s.io/apimachinery/pkg/apis/meta/v1",
+    "k8s.io/apimachinery/pkg/util/wait",
+    "k8s.io/client-go/kubernetes",
+    "k8s.io/client-go/plugin/pkg/client/auth",
+    "k8s.io/client-go/rest",
+    "k8s.io/client-go/tools/clientcmd",
+    "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1",
+    "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset",
+    "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -20,12 +20,34 @@
 #  name = "github.com/x/y"
 #  version = "2.4.0"
 
-
 [[constraint]]
   name = "k8s.io/client-go"
-  version = "6.0.0"
+  branch = "release-8.0"
+
+[[constraint]]
+  name = "k8s.io/api"
+  branch = "release-1.11"
+  
+[[constraint]]
+  name = "k8s.io/apimachinery"
+  branch = "release-1.11"
+
+[[constraint]]
+  name = "k8s.io/kube-aggregator"
+  branch = "release-1.11"
+
+[[constraint]]
+  name = "k8s.io/kubernetes"
+  branch = "release-1.11"
+
+[[override]]
+  name = "k8s.io/apiserver"
+  branch = "release-1.11"
+
+[[override]]
+  name = "k8s.io/apiextensions-apiserver"
+  branch = "release-1.11"
 
 [[override]]
   name = "github.com/Azure/go-autorest"
-  # This is the version required by k8s.io/client-go v6.0.0
-  version = "9.1.0"
+  revision = "bca49d5b51a50dc5bb17bbf6204c711c6dbded06"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ wcg --service-name=foo --namespace=bar --secret-name=foo-certs
 ```
 
 This generates a CSR with the name `foo.bar` (`servicename.namespace`) in the
-K8s API and waits for it's approval.
+K8s API and waits for its approval.
 
 Once the CSR is approved, `wcg` waits for the certificate to be signed and then
 creates a secret `foo-certs` with the following format:
@@ -73,6 +73,9 @@ the name of the Webhook configuration (eg `--patch-mutating=foo-webhook`) and
 `wcg` will patch the `caBundle` field with the cluster's CA Bundle once the
 certificate has been issued.
 
+If you are using the [aggregated API server](https://kubernetes.io/blog/2018/01/extensible-admission-is-beta) you
+can also pass an APIService name using `--patch-api-service` to patch the `caBundle` field as previously described. 
+
 ### Flags
 The following flags are configure the certificate generation process.
 `namespace`, `secret-name` and `service-name` are required.
@@ -81,6 +84,7 @@ The following flags are configure the certificate generation process.
       --in-cluster                       Running inside a Kubernetes Cluster (default true)
   -k, --kubeconfig string                Kubeconfig file to use
   -n, --namespace string                 Service Namespace
+      --patch-api-service string         Name of APIService to patch CABundle into
       --patch-mutating string            Name of MutatingWebhookConfiguration to patch CABundle into
       --patch-validating string          Name of ValidatingWebhookConfiguration to patch CABundle into
   -o, --secret-name string               Secret name to put certificates in

--- a/cmd/webhook-certificate-generator/main.go
+++ b/cmd/webhook-certificate-generator/main.go
@@ -36,6 +36,7 @@ func main() {
 
 	cmd.Flags().StringVar(&config.PatchMutating, "patch-mutating", "", "Name of MutatingWebhookConfiguration to patch CABundle into")
 	cmd.Flags().StringVar(&config.PatchValidating, "patch-validating", "", "Name of ValidatingWebhookConfiguration to patch CABundle into")
+	cmd.Flags().StringVar(&config.PatchApiService, "patch-api-service", "", "Name of APIService to patch CABundle into")
 
 	cmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
 	cmd.PersistentFlags().Set("logtostderr", "True")

--- a/pkg/certgenerator/csr.go
+++ b/pkg/certgenerator/csr.go
@@ -16,8 +16,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-// createCerificateSigningRequest creates a Kubernetes CSR for the given service
-func createCerificateSigningRequest(client *kubernetes.Clientset, secret *v1.Secret, namespace string, serviceName string, secretName string) (string, error) {
+// createCertificateSigningRequest creates a Kubernetes CSR for the given service
+func createCertificateSigningRequest(client *kubernetes.Clientset, secret *v1.Secret, namespace string, serviceName string, secretName string) (string, error) {
 	csrPem, err := createCSRPem(secret, namespace, serviceName)
 	if err != nil {
 		return "", fmt.Errorf("failed to create CSR Pem: %v", err)

--- a/pkg/certgenerator/patch.go
+++ b/pkg/certgenerator/patch.go
@@ -2,14 +2,17 @@ package certgenerator
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/joelspeed/webhook-certificate-generator/pkg/utils"
 	arv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	"k8s.io/client-go/kubernetes"
+	aggregatorclient "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset"
 )
 
-func patchMutating(client *kubernetes.Clientset, name string, namespace string, service string) error {
+func patchMutating(client *kubernetes.Clientset, name string, namespace string, service string, apiServiceGroup string) error {
 	caBundle, err := fetchCABundle(client)
+
 	if err != nil {
 		return fmt.Errorf("error retrieving ca bundle: %v", err)
 	}
@@ -19,7 +22,8 @@ func patchMutating(client *kubernetes.Clientset, name string, namespace string, 
 		return fmt.Errorf("failed to fetch mutating webhook configuration: %v", err)
 	}
 
-	mwc.Webhooks = patchWebhooks(mwc.Webhooks, caBundle, namespace, service)
+	mwc.Webhooks = patchWebhooks(mwc.Webhooks, caBundle, namespace, service, apiServiceGroup)
+
 	_, err = utils.UpdateMutatingWebhookConfiguration(client, mwc)
 	if err != nil {
 		return fmt.Errorf("failed updating mutating webhook configuration: %v", err)
@@ -27,7 +31,7 @@ func patchMutating(client *kubernetes.Clientset, name string, namespace string, 
 	return nil
 }
 
-func patchValidating(client *kubernetes.Clientset, name string, namespace string, service string) error {
+func patchValidating(client *kubernetes.Clientset, name string, namespace string, service string, apiServiceGroup string) error {
 	caBundle, err := fetchCABundle(client)
 	if err != nil {
 		return fmt.Errorf("error retrieving ca bundle: %v", err)
@@ -38,10 +42,31 @@ func patchValidating(client *kubernetes.Clientset, name string, namespace string
 		return fmt.Errorf("failed to fetch validating webhook configuration: %v", err)
 	}
 
-	vwc.Webhooks = patchWebhooks(vwc.Webhooks, caBundle, namespace, service)
+	vwc.Webhooks = patchWebhooks(vwc.Webhooks, caBundle, namespace, service, apiServiceGroup)
 	_, err = utils.UpdateValidatingWebhookConfiguration(client, vwc)
 	if err != nil {
 		return fmt.Errorf("failed updating validating webhook configuration: %v", err)
+	}
+	return nil
+}
+
+func patchAPIService(kubeclient *kubernetes.Clientset, client *aggregatorclient.Clientset, name string) error {
+	caBundle, err := fetchCABundle(kubeclient)
+	if err != nil {
+		return fmt.Errorf("error retrieving ca bundle: %v", err)
+	}
+
+	svc, err := utils.GetAPIServiceConfiguration(client, name)
+	if err != nil {
+		return fmt.Errorf("failed to fetch api service configuration: %v", err)
+	}
+
+	svc.Spec.InsecureSkipTLSVerify = false
+	svc.Spec.CABundle = caBundle
+
+	_, err = utils.UpdateAPIServiceConfiguration(client, svc)
+	if err != nil {
+		return fmt.Errorf("failed updating api service configuration: %v", err)
 	}
 	return nil
 }
@@ -57,11 +82,17 @@ func fetchCABundle(client *kubernetes.Clientset) ([]byte, error) {
 	return nil, fmt.Errorf("no client-ca-file in configmap")
 }
 
-func patchWebhooks(webhooks []arv1beta1.Webhook, caBundle []byte, namespace string, name string) []arv1beta1.Webhook {
+func patchWebhooks(webhooks []arv1beta1.Webhook, caBundle []byte, namespace string, name string, apiServiceGroup string) []arv1beta1.Webhook {
 	outWebhooks := []arv1beta1.Webhook{}
 	for _, wh := range webhooks {
-		if wh.ClientConfig.Service.Namespace == namespace &&
-			wh.ClientConfig.Service.Name == name {
+
+		matchesService := wh.ClientConfig.Service.Namespace == namespace && wh.ClientConfig.Service.Name == name
+		matchesAggregatedAPI := apiServiceGroup != "" &&
+			wh.ClientConfig.Service.Namespace == "default" &&
+			wh.ClientConfig.Service.Name == "kubernetes" &&
+			strings.HasPrefix(*wh.ClientConfig.Service.Path, apiServiceGroup)
+
+		if matchesService || matchesAggregatedAPI {
 			wh.ClientConfig.CABundle = caBundle
 		}
 		outWebhooks = append(outWebhooks, wh)

--- a/pkg/utils/apiserviceconfiguration.go
+++ b/pkg/utils/apiserviceconfiguration.go
@@ -1,0 +1,20 @@
+package utils
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kav1beta1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
+	aggregatorclient "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset"
+)
+
+// GetAPIServiceConfiguration gets the names api service configuration
+// from kubernetes
+func GetAPIServiceConfiguration(aggrclient *aggregatorclient.Clientset, name string) (*kav1beta1.APIService, error) {
+	getOpts := metav1.GetOptions{}
+	return aggrclient.ApiregistrationV1beta1().APIServices().Get(name, getOpts)
+}
+
+// UpdateAPIServiceCongiguration updates the api service configuration
+// given
+func UpdateAPIServiceConfiguration(aggrclient *aggregatorclient.Clientset, svc *kav1beta1.APIService) (*kav1beta1.APIService, error) {
+	return aggrclient.ApiregistrationV1beta1().APIServices().Update(svc)
+}

--- a/pkg/utils/client.go
+++ b/pkg/utils/client.go
@@ -8,6 +8,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	aggregatorclient "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset"
 )
 
 // NewClientset creates a kubernetes clientset.
@@ -19,6 +20,17 @@ func NewClientset(inCluster bool, kubeconfig string) (*kubernetes.Clientset, err
 	}
 
 	return kubernetes.NewForConfig(config)
+}
+
+// NewAggregatorClientset creates a kubernetes clientset.
+// Will load config from Pod environment if running in cluster.
+func NewAggregatorClientset(inCluster bool, kubeconfig string) (*aggregatorclient.Clientset, error) {
+	config, err := createConfig(inCluster, kubeconfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load config: %v", err)
+	}
+
+	return aggregatorclient.NewForConfig(config)
 }
 
 func createConfig(inCluster bool, kubeconfig string) (*rest.Config, error) {


### PR DESCRIPTION
**Summary**
- Adds support for patching the `caBundle` into `APIService` resource and aggregated API webhooks
- Bumps and adds some dependencies as required
- Fixes some minor and unrelated typos

**Details**

Hi Joel! I found your project linked from https://github.com/istio/istio/issues/3821#issuecomment-371449886. I'm prototyping my first Mutating Webhook, and ran into the same issues as you with automatically provisioning the TLS certificates. Thank you for your work, it's been very helpful!

I'm curious to hear your opinions on this (very rough) PR. From what I've seen there are 2 ways of dealing with admission controllers:

- By writing a simple HTTP server and registering a WebhookConfiguration with that endpoint, e.g. https://github.com/banzaicloud/admission-webhook-example/tree/blog
- Or by building a webhook admission server to also be an [extension API server](https://kubernetes.io/blog/2018/01/extensible-admission-is-beta/), e.g. https://github.com/openshift/kubernetes-namespace-reservation

I've been following this latter example from OpenShift, but this means I have an additional `APIService` resource that looks like:

```
- apiVersion: apiregistration.k8s.io/v1beta1
  kind: APIService
  metadata:
    name: v1beta1.admission.online.budeanu.com
  spec:
    insecureSkipTLSVerify: false
    caBundle: ""
    group: admission.online.budeanu.com
    groupPriorityMinimum: 1000
    versionPriority: 15
    service:
      name: widget-admission-controller
      namespace: default
    version: v1beta1
```

Your project currently supports auto-injecting the `caBundle` into the webhooks, but it must also be inserted into the `APIService` above. This PR adds support to optionally patch these resources.

An added complication is that the webhooks now look a little different, for example:

```
- apiVersion: admissionregistration.k8s.io/v1beta1
  kind: MutatingWebhookConfiguration
  metadata:
    name: pods.admission.online.budeanu.com
  webhooks:
  - name: pods.admission.online.budeanu.com
    clientConfig:
      service:
        # reach the webhook via the registered aggregated API
        namespace: default
        name: kubernetes
        path: /apis/admission.online.budeanu.com/v1beta1/pods
      caBundle: ""
    rules:
    - operations:
      - CREATE
      - UPDATE
      apiGroups:
      - ""
      apiVersions:
      - "*"
      resources:
      - pods
    failurePolicy: Ignore
```

Note that due to the additional indirection of the aggregation API the target service in this case is actually the `kubernetes` service in the `default` namespace. To handle this case I've prototyped a solution where the group/version in the `path` of the service is compared with that of the API Service.

Does (the spirit of) this change make sense to you?

In the [OpenShift Example](https://github.com/openshift/kubernetes-namespace-reservation/blob/master/hack/install-kube.sh#L70) they provision certificates manually, but I'm trying to avoid having to manage them myself at all costs. Extending `webhook-certificate-generator` to work in this case seemed like a reasonable thing to do.

Thanks for your time, looking forward to hearing your thoughts!