### PR TITLE
job.yaml - target release tagged image

### DIFF
--- a/install/kubernetes/job.yaml
+++ b/install/kubernetes/job.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: certificate-generator
       containers:
         - name: webhook-certificate-generator
-          image: quay.io/joelspeed/webhook-certificate-generator
+          image: quay.io/joelspeed/webhook-certificate-generator:v0.1.1
           imagePullPolicy: Always
           args:
             - --service-name=${service-name}


### PR DESCRIPTION
There seems to be a mismatch between the Role and the code in the image `quay.io/joelspeed/webhook-certificate-generator` (which resolves to `:latest`). 

The `:latest` image still needs the `list` verb on secrets, but it has been removed from the Role.

An alternative to this PR is to push `quay.io/joelspeed/webhook-certificate-generator:v0.1.1` to `:latest`.