### PR TITLE
Use PKCS1 rsa private key preamble

### DIFF
--- a/pkg/certgenerator/csr.go
+++ b/pkg/certgenerator/csr.go
@@ -93,7 +93,7 @@ func getPrivateKey(secret *v1.Secret) (*rsa.PrivateKey, error) {
 	}
 
 	pemBlock := &pem.Block{
-		Type:  "PRIVATE KEY",
+		Type:  "RSA PRIVATE KEY",
 		Bytes: x509.MarshalPKCS1PrivateKey(newKey),
 	}
 


### PR DESCRIPTION
The generated private key uses the preamble `-----BEGIN PRIVATE KEY----`  which indicates a PKCS8 encoding, however the private key payload appears to conform to PKCS1 with no cipher information. I think this makes sense as you call `MarshalPKCS1PrivateKey`.

This mismatch between the preamble and payload caused me some problems. openssl can't decode the private key (unless you fix the preamble). After fixing the preamble I used openssl to convert the key to PKCS8 and confirmed the payload is indeed different.

This also tripped up Python SSL.